### PR TITLE
rewrite watches to use changefeeds to imitate ZK semantics

### DIFF
--- a/src/main/java/com/ph14/fdb/zk/layer/FdbWatchManager.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbWatchManager.java
@@ -1,140 +1,52 @@
 package com.ph14.fdb.zk.layer;
 
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
-
-import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.Watcher.Event.EventType;
-import org.apache.zookeeper.Watcher.Event.KeeperState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.apple.foundationdb.Database;
-import com.apple.foundationdb.MutationType;
 import com.apple.foundationdb.Transaction;
-import com.apple.foundationdb.directory.DirectoryLayer;
-import com.apple.foundationdb.directory.DirectorySubspace;
-import com.apple.foundationdb.tuple.Tuple;
-import com.apple.foundationdb.tuple.Versionstamp;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 import com.google.inject.Inject;
+import com.ph14.fdb.zk.layer.changefeed.WatchEventChangefeed;
 
-/**
- * Uses the DirectoryLayer to allocate a small keyspace for
- * creation / update / deletes watches. When these events
- * occur, the keys are written with a versionstamp mutation
- * that trigger watches
- */
+// TODO: Still need this class?
 public class FdbWatchManager {
 
-  private static final Logger LOG = LoggerFactory.getLogger(FdbWatchManager.class);
-
-  private static final String WATCH_DIRECTORY = "fdb-zk-watch";
-
-  private static final byte[] CREATED_NODE_PATH = new byte[] { 1 };
-  private static final byte[] DELETED_NODE_PATH = new byte[] { 2 };
-  private static final byte[] UPDATED_NODE_PATH = new byte[] { 3 };
-  private static final byte[] CHILDREN_NODE_PATH = new byte[] { 4 };
-
-  private final ListMultimap<Watcher, CompletableFuture<Void>> watchesByWatcher = ArrayListMultimap.create();
-
-  private final byte[] versionstampValue;
-  private final DirectorySubspace directorySubspace;
+  private final WatchEventChangefeed watchChangefeed;
 
   @Inject
-  public FdbWatchManager(Database database) {
-    this.directorySubspace = database.run(tr ->
-        DirectoryLayer.getDefault().createOrOpen(tr, Collections.singletonList(WATCH_DIRECTORY)).join());
-    this.versionstampValue = Tuple.from(Versionstamp.incomplete()).packWithVersionstamp();
+  public FdbWatchManager(WatchEventChangefeed watchChangefeed) {
+    this.watchChangefeed = watchChangefeed;
   }
 
   public void triggerNodeCreatedWatch(Transaction transaction, String zkPath) {
-    transaction.mutate(MutationType.SET_VERSIONSTAMPED_VALUE, getCreatedWatchPath(zkPath), versionstampValue);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeCreated, zkPath);
   }
 
   public void triggerNodeUpdatedWatch(Transaction transaction, String zkPath) {
-    transaction.mutate(MutationType.SET_VERSIONSTAMPED_VALUE, getUpdatedWatchPath(zkPath), versionstampValue);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeDataChanged, zkPath);
   }
 
   public void triggerNodeDeletedWatch(Transaction transaction, String zkPath) {
-    transaction.mutate(MutationType.SET_VERSIONSTAMPED_VALUE, getDeletedWatchPath(zkPath), versionstampValue);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeDeleted, zkPath);
   }
 
   public void triggerNodeChildrenWatch(Transaction transaction, String zkPath) {
-    transaction.mutate(MutationType.SET_VERSIONSTAMPED_VALUE, getChildrenWatchPath(zkPath), versionstampValue);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeChildrenChanged, zkPath);
   }
 
-  public void addNodeCreatedWatch(Transaction transaction, String zkPath, Watcher watcher) {
-    synchronized (watchesByWatcher) {
-      CompletableFuture<Void> watch = transaction.watch(getCreatedWatchPath(zkPath));
-      watch.whenComplete(createWatchCallback(watcher, zkPath, EventType.NodeCreated));
-
-      watchesByWatcher.put(watcher, watch);
-    }
+  public void addNodeCreatedWatch(Transaction transaction, String zkPath, Watcher watcher, long sessionId) {
+    watchChangefeed.setZKChangefeedWatch(transaction, watcher, sessionId, EventType.NodeCreated, zkPath);
   }
 
-  public void addNodeDataUpdatedWatch(Transaction transaction, String zkPath, Watcher watcher) {
-    synchronized (watchesByWatcher) {
-      CompletableFuture<Void> watch = transaction.watch(getUpdatedWatchPath(zkPath));
-      watch.whenComplete(createWatchCallback(watcher, zkPath, EventType.NodeDataChanged));
-
-      watchesByWatcher.put(watcher, watch);
-    }
+  public void addNodeDataUpdatedWatch(Transaction transaction, String zkPath, Watcher watcher, long sessionId) {
+    watchChangefeed.setZKChangefeedWatch(transaction, watcher, sessionId, EventType.NodeDataChanged, zkPath);
   }
 
-  public void addNodeDeletedWatch(Transaction transaction, String zkPath, Watcher watcher) {
-    synchronized (watchesByWatcher) {
-      CompletableFuture<Void> watch = transaction.watch(getDeletedWatchPath(zkPath));
-      watch.whenComplete(createWatchCallback(watcher, zkPath, EventType.NodeDeleted));
-
-      watchesByWatcher.put(watcher, watch);
-    }
+  public void addNodeDeletedWatch(Transaction transaction, String zkPath, Watcher watcher, long sessionId) {
+    watchChangefeed.setZKChangefeedWatch(transaction, watcher, sessionId, EventType.NodeDeleted, zkPath);
   }
 
-  public void addNodeChildrenWatch(Transaction transaction, String zkPath, Watcher watcher) {
-    synchronized (watchesByWatcher) {
-      CompletableFuture<Void> watch = transaction.watch(getChildrenWatchPath(zkPath));
-      watch.whenComplete(createWatchCallback(watcher, zkPath, EventType.NodeChildrenChanged));
-
-      watchesByWatcher.put(watcher, watch);
-    }
-  }
-
-  private BiConsumer<Void, Throwable> createWatchCallback(Watcher watcher, String zkPath, EventType eventType) {
-    return (v, e) -> {
-      if (e != null) {
-        throw new RuntimeException(e);
-      }
-
-      synchronized (watchesByWatcher) {
-        if (watchesByWatcher.get(watcher).isEmpty()) {
-          return;
-        }
-
-        watcher.process(new WatchedEvent(eventType, KeeperState.SyncConnected, zkPath));
-
-        watchesByWatcher.get(watcher).clear();
-      }
-    };
-  }
-
-  private byte[] getCreatedWatchPath(String zkPath) {
-    return directorySubspace.pack(Tuple.from(CREATED_NODE_PATH, zkPath));
-  }
-
-  private byte[] getDeletedWatchPath(String zkPath) {
-    return directorySubspace.pack(Tuple.from(DELETED_NODE_PATH, zkPath));
-  }
-
-  private byte[] getUpdatedWatchPath(String zkPath) {
-    return directorySubspace.pack(Tuple.from(UPDATED_NODE_PATH, zkPath));
-  }
-
-  private byte[] getChildrenWatchPath(String zkPath) {
-    return directorySubspace.pack(Tuple.from(CHILDREN_NODE_PATH, zkPath));
+  public void addNodeChildrenWatch(Transaction transaction, String zkPath, Watcher watcher, long sessionId) {
+    watchChangefeed.setZKChangefeedWatch(transaction, watcher, sessionId, EventType.NodeChildrenChanged, zkPath);
   }
 
 }

--- a/src/main/java/com/ph14/fdb/zk/layer/changefeed/ChangefeedWatchEvent.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/changefeed/ChangefeedWatchEvent.java
@@ -1,0 +1,62 @@
+package com.ph14.fdb.zk.layer.changefeed;
+
+import java.util.Objects;
+
+import org.apache.zookeeper.Watcher.Event.EventType;
+
+import com.apple.foundationdb.tuple.Versionstamp;
+import com.google.common.base.MoreObjects;
+
+public class ChangefeedWatchEvent {
+
+  private final Versionstamp versionstamp;
+  private final EventType eventType;
+  private final String zkPath;
+
+  public ChangefeedWatchEvent(Versionstamp versionstamp, EventType eventType, String zkPath) {
+    this.versionstamp = versionstamp;
+    this.eventType = eventType;
+    this.zkPath = zkPath;
+  }
+
+  public Versionstamp getVersionstamp() {
+    return versionstamp;
+  }
+
+  public EventType getEventType() {
+    return eventType;
+  }
+
+  public String getZkPath() {
+    return zkPath;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj instanceof ChangefeedWatchEvent) {
+      final ChangefeedWatchEvent that = (ChangefeedWatchEvent) obj;
+      return Objects.equals(this.getVersionstamp(), that.getVersionstamp())
+          && Objects.equals(this.getEventType(), that.getEventType())
+          && Objects.equals(this.getZkPath(), that.getZkPath());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getVersionstamp(), getEventType(), getZkPath());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("versionstamp", versionstamp)
+        .add("eventType", eventType)
+        .add("zkPath", zkPath)
+        .toString();
+  }
+
+}

--- a/src/main/java/com/ph14/fdb/zk/layer/changefeed/WatchEventChangefeed.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/changefeed/WatchEventChangefeed.java
@@ -1,0 +1,153 @@
+package com.ph14.fdb.zk.layer.changefeed;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.Watcher.Event.EventType;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.MutationType;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.apple.foundationdb.tuple.Tuple;
+import com.apple.foundationdb.tuple.Versionstamp;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.inject.Inject;
+
+public class WatchEventChangefeed {
+
+  private static final String ACTIVE_WATCH_NAMESPACE = "fdb-zk-watch-active";
+  private static final String CHANGEFEED_TRIGGER_NAMESPACE = "fdb-zk-watch-trigger";
+  private static final String CHANGEFEED_NAMESPACE = "fdb-zk-watch-cf";
+
+  private static final byte[] EMPTY_VALUE = new byte[0];
+
+  // TODO: this can currently grow without bound, since it doesn't evict stale Watchers
+  private final ConcurrentHashMap<Watcher, ReentrantLock> changefeedLocks;
+
+  private final Database database;
+
+  @Inject
+  public WatchEventChangefeed(Database database) {
+    this.database = database;
+    this.changefeedLocks = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Sets a ZK Watch on a particular ZKPath for a given event type.
+   *
+   * To do this, it:
+   *
+   * 1. Marks that the client is actively watching a given (zkPath, eventType)
+   * 2. Subscribes the client to a FDB watch for the ZK Watch Trigger
+   */
+  public void setZKChangefeedWatch(Transaction transaction, Watcher watcher, long sessionId, EventType eventType, String zkPath) {
+    // register as a ZK watcher for a given path + event type
+    transaction.set(getActiveWatchKey(sessionId, zkPath, eventType), EMPTY_VALUE);
+
+    // subscribe to the trigger-key, to avoid having to poll for watch events
+    CompletableFuture<Void> triggerFuture = transaction.watch(getTriggerKey(sessionId, eventType));
+    triggerFuture.whenComplete((v, e) -> playChangefeed(sessionId, watcher));
+  }
+
+  /**
+   * * Add an update to the changefeed for a (session, watchEventType, zkPath)
+   * * Triggers all FDB watches for the changefeed
+   */
+  public void appendToChangefeed(Transaction transaction, EventType eventType, String zkPath) {
+    Range activeWatches = Range.startsWith(Tuple.from(ACTIVE_WATCH_NAMESPACE, zkPath, eventType.getIntValue()).pack());
+    List<KeyValue> keyValues = transaction.getRange(activeWatches).asList().join();
+
+    for (KeyValue keyValue : keyValues) {
+      long sessionId = Tuple.fromBytes(keyValue.getKey()).getLong(3);
+
+      Tuple changefeedKey = Tuple.from(CHANGEFEED_NAMESPACE, sessionId, Versionstamp.incomplete(), eventType.getIntValue());
+      // append the event to the changefeed of each ZK watcher
+      transaction.mutate(MutationType.SET_VERSIONSTAMPED_KEY, changefeedKey.packWithVersionstamp(), Tuple.from(zkPath).pack());
+
+      // update the watched trigger-key for each ZK watcher, so they know to check their changefeeds for updates
+      transaction.mutate(
+          MutationType.SET_VERSIONSTAMPED_VALUE,
+          Tuple.from(CHANGEFEED_TRIGGER_NAMESPACE, sessionId, eventType.getIntValue()).pack(),
+          Tuple.from(Versionstamp.incomplete()).packWithVersionstamp());
+    }
+
+    transaction.clear(activeWatches);
+  }
+
+  private static byte[] getActiveWatchKey(long sessionId, String zkPath, EventType eventType) {
+    return Tuple.from(ACTIVE_WATCH_NAMESPACE, zkPath, eventType.getIntValue(), sessionId).pack();
+  }
+
+  private static byte[] getTriggerKey(long sessionId, EventType eventType) {
+    return Tuple.from(CHANGEFEED_TRIGGER_NAMESPACE, sessionId, eventType.getIntValue()).pack();
+  }
+
+  private void playChangefeed(long sessionId, Watcher watcher) {
+    synchronized (changefeedLocks) {
+      changefeedLocks.computeIfAbsent(watcher, x -> new ReentrantLock());
+    }
+
+    try {
+      // We don't want concurrent changefeed lookups to duplicate events to the same client.
+      changefeedLocks.get(watcher).lock();
+
+      Range allAvailableZKWatchEvents = Range.startsWith(Tuple.from(CHANGEFEED_NAMESPACE, sessionId).pack());
+
+      List<ChangefeedWatchEvent> watchEvents = database.run(
+          transaction -> transaction.getRange(allAvailableZKWatchEvents).asList())
+          .thenApply(kvs -> kvs.stream()
+              .map(WatchEventChangefeed::toWatchEvent)
+              .collect(ImmutableList.toImmutableList()))
+          .join();
+
+      if (watchEvents.isEmpty()) {
+        changefeedLocks.get(watcher).unlock();
+        return;
+      }
+
+      Set<ByteBuffer> seenCommitVersionstamps = new HashSet<>(watchEvents.size());
+      for (ChangefeedWatchEvent watchEvent : watchEvents) {
+        ByteBuffer watchCommitVersion = ByteBuffer.wrap(watchEvent.getVersionstamp().getTransactionVersion());
+
+        // in the case that one transaction committed multiple watches for different event types (e.g. getData),
+        // we only want to trigger one of the watches. TBH this might only be needed for one of the test cases, not sure
+        if (seenCommitVersionstamps.add(watchCommitVersion)) {
+          watcher.process(new WatchedEvent(watchEvent.getEventType(), KeeperState.SyncConnected, watchEvent.getZkPath()));
+        }
+      }
+
+      Versionstamp greatestVersionstamp = Iterables.getLast(watchEvents).getVersionstamp();
+      database.run(transaction -> {
+        // if watch entries were written between reading and executing, we want to only remove entries up to what we just had
+        byte[] lastProcessedEvent = ByteArrayUtil.strinc(Tuple.from(CHANGEFEED_NAMESPACE, sessionId, greatestVersionstamp).pack());
+        transaction.clear(allAvailableZKWatchEvents.begin, lastProcessedEvent);
+
+        return null;
+      });
+    } finally {
+      changefeedLocks.get(watcher).unlock();
+    }
+  }
+
+  private static ChangefeedWatchEvent toWatchEvent(KeyValue keyValue) {
+    Tuple tuple = Tuple.fromBytes(keyValue.getKey());
+    Versionstamp versionstamp = tuple.getVersionstamp(2);
+    EventType eventType = EventType.fromInt((int) tuple.getLong(3)); // tuple layer upcasts ints to longs
+    String zkPath = Tuple.fromBytes(keyValue.getValue()).getString(0);
+
+    return new ChangefeedWatchEvent(versionstamp, eventType, zkPath);
+  }
+
+}

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbExistsOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbExistsOp.java
@@ -48,15 +48,15 @@ public class FdbExistsOp implements FdbOp<ExistsRequest, ExistsResponse> {
       FdbNode fdbNode = fdbNodeReader.getNode(subspace, transaction.getRange(statKeyRange).asList().join());
 
       if (request.getWatch()) {
-        fdbWatchManager.addNodeDataUpdatedWatch(transaction, request.getPath(), zkRequest.cnxn);
-        fdbWatchManager.addNodeDeletedWatch(transaction, request.getPath(), zkRequest.cnxn);
+        fdbWatchManager.addNodeDataUpdatedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
+        fdbWatchManager.addNodeDeletedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
       }
 
       return CompletableFuture.completedFuture(Result.ok(new ExistsResponse(fdbNode.getStat())));
     } catch (CompletionException e) {
       if (e.getCause() instanceof NoSuchDirectoryException) {
         if (request.getWatch()) {
-          fdbWatchManager.addNodeCreatedWatch(transaction, request.getPath(), zkRequest.cnxn);
+          fdbWatchManager.addNodeCreatedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
         }
 
         return CompletableFuture.completedFuture(Result.err(new NoNodeException(request.getPath())));

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbGetChildrenWithStatOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbGetChildrenWithStatOp.java
@@ -41,8 +41,8 @@ public class FdbGetChildrenWithStatOp implements FdbOp<GetChildren2Request, GetC
       List<String> childrenDirectoryNames = DirectoryLayer.getDefault().list(transaction, path).join();
 
       if (request.getWatch()) {
-        fdbWatchManager.addNodeChildrenWatch(transaction, request.getPath(), zkRequest.cnxn);
-        fdbWatchManager.addNodeDeletedWatch(transaction, request.getPath(), zkRequest.cnxn);
+        fdbWatchManager.addNodeChildrenWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
+        fdbWatchManager.addNodeDeletedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
       }
 
       return CompletableFuture.completedFuture(Result.ok(new GetChildren2Response(childrenDirectoryNames, stat)));

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbGetDataOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbGetDataOp.java
@@ -48,7 +48,7 @@ public class FdbGetDataOp implements FdbOp<GetDataRequest, GetDataResponse> {
       if (e.getCause() instanceof NoSuchDirectoryException) {
         if (request.getWatch()) {
           LOG.info("Setting watch on node creation {}", request.getPath());
-          fdbWatchManager.addNodeCreatedWatch(transaction, request.getPath(), zkRequest.cnxn);
+          fdbWatchManager.addNodeCreatedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
         }
 
         return CompletableFuture.completedFuture(Result.err(new NoNodeException(request.getPath())));
@@ -61,8 +61,8 @@ public class FdbGetDataOp implements FdbOp<GetDataRequest, GetDataResponse> {
     CompletableFuture<FdbNode> fdbNode = fdbNodeReader.getNode(subspace, transaction);
 
     if (request.getWatch()) {
-      fdbWatchManager.addNodeDataUpdatedWatch(transaction, request.getPath(), zkRequest.cnxn);
-      fdbWatchManager.addNodeDeletedWatch(transaction, request.getPath(), zkRequest.cnxn);
+      fdbWatchManager.addNodeDataUpdatedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
+      fdbWatchManager.addNodeDeletedWatch(transaction, request.getPath(), zkRequest.cnxn, zkRequest.sessionId);
     }
 
     return CompletableFuture.completedFuture(Result.ok(new GetDataResponse(fdbNode.join().getData(), fdbNode.join().getStat())));

--- a/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
+++ b/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
@@ -18,6 +18,7 @@ import com.ph14.fdb.zk.layer.FdbNodeReader;
 import com.ph14.fdb.zk.layer.FdbNodeWriter;
 import com.ph14.fdb.zk.layer.FdbPath;
 import com.ph14.fdb.zk.layer.FdbWatchManager;
+import com.ph14.fdb.zk.layer.changefeed.WatchEventChangefeed;
 import com.ph14.fdb.zk.ops.FdbCreateOp;
 import com.ph14.fdb.zk.ops.FdbDeleteOp;
 import com.ph14.fdb.zk.ops.FdbExistsOp;
@@ -31,7 +32,7 @@ public class FdbBaseTest {
   protected static final String BASE_PATH = "/foo";
   protected static final String SUBPATH = "/foo/bar";
   protected static final MockFdbServerCnxn SERVER_CNXN = new MockFdbServerCnxn();
-  protected static final Request REQUEST = new Request(SERVER_CNXN, System.currentTimeMillis(), 1, 2, null, Collections.emptyList());
+  protected static Request REQUEST = new Request(SERVER_CNXN, System.currentTimeMillis(), 1, 2, null, Collections.emptyList());
 
   protected FdbNodeWriter fdbNodeWriter;
   protected FdbWatchManager fdbWatchManager;
@@ -53,9 +54,10 @@ public class FdbBaseTest {
     this.fdb = FDB.selectAPIVersion(600).open();
 
     SERVER_CNXN.clearWatchedEvents();
+    REQUEST = new Request(SERVER_CNXN, System.nanoTime(), 1, 2, null, Collections.emptyList());
 
     fdbNodeWriter = new FdbNodeWriter();
-    fdbWatchManager = new FdbWatchManager(fdb);
+    fdbWatchManager = new FdbWatchManager(new WatchEventChangefeed(fdb));
     fdbNodeReader = new FdbNodeReader();
 
     fdbCreateOp = new FdbCreateOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager);

--- a/src/test/java/com/ph14/fdb/zk/ops/FdbCreateOpTest.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/FdbCreateOpTest.java
@@ -115,7 +115,7 @@ public class FdbCreateOpTest extends FdbBaseTest {
     };
 
     fdb.run(tr -> {
-      fdbWatchManager.addNodeCreatedWatch(tr, BASE_PATH, watcher);
+      fdbWatchManager.addNodeCreatedWatch(tr, BASE_PATH, watcher, REQUEST.sessionId);
       return null;
     });
 
@@ -139,7 +139,7 @@ public class FdbCreateOpTest extends FdbBaseTest {
     };
 
     fdb.run(tr -> {
-      fdbWatchManager.addNodeChildrenWatch(tr, "/", watcher);
+      fdbWatchManager.addNodeChildrenWatch(tr, "/", watcher, REQUEST.sessionId);
       return null;
     });
 

--- a/src/test/java/com/ph14/fdb/zk/ops/FdbDeleteOpTest.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/FdbDeleteOpTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
-import java.util.concurrent.CompletionException;
 
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
@@ -18,6 +17,7 @@ import org.junit.Test;
 
 import com.hubspot.algebra.Result;
 import com.ph14.fdb.zk.FdbBaseTest;
+import com.ph14.fdb.zk.layer.changefeed.WatchEventChangefeed;
 
 public class FdbDeleteOpTest extends FdbBaseTest {
 
@@ -103,7 +103,7 @@ public class FdbDeleteOpTest extends FdbBaseTest {
     assertThat(exists.unwrapOrElseThrow().getStat().getNumChildren()).isEqualTo(1);
     long initialPzxid = exists.unwrapOrElseThrow().getStat().getPzxid();
 
-    FdbDeleteOp throwingFdbDeleteOp = new FdbDeleteOp(fdbNodeReader, fdbNodeWriter, new ThrowingWatchManager(fdb));
+    FdbDeleteOp throwingFdbDeleteOp = new FdbDeleteOp(fdbNodeReader, fdbNodeWriter, new ThrowingWatchManager(new WatchEventChangefeed(fdb)));
     assertThatThrownBy(() -> fdb.run(tr -> throwingFdbDeleteOp.execute(REQUEST, tr, new DeleteRequest(SUBPATH, 0))))
         .hasCauseInstanceOf(RuntimeException.class);
 

--- a/src/test/java/com/ph14/fdb/zk/ops/FdbSetDataOpTest.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/FdbSetDataOpTest.java
@@ -96,7 +96,7 @@ public class FdbSetDataOpTest extends FdbBaseTest {
     };
 
     fdb.run(tr -> {
-      fdbWatchManager.addNodeDataUpdatedWatch(tr, BASE_PATH, watcher);
+      fdbWatchManager.addNodeDataUpdatedWatch(tr, BASE_PATH, watcher, REQUEST.sessionId);
       return null;
     });
 

--- a/src/test/java/com/ph14/fdb/zk/ops/ThrowingWatchManager.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/ThrowingWatchManager.java
@@ -2,13 +2,13 @@ package com.ph14.fdb.zk.ops;
 
 import java.util.concurrent.CompletionException;
 
-import com.apple.foundationdb.Database;
 import com.apple.foundationdb.Transaction;
 import com.ph14.fdb.zk.layer.FdbWatchManager;
+import com.ph14.fdb.zk.layer.changefeed.WatchEventChangefeed;
 
 class ThrowingWatchManager extends FdbWatchManager {
-  public ThrowingWatchManager(Database database) {
-    super(database);
+  public ThrowingWatchManager(WatchEventChangefeed watchEventChangefeed) {
+    super(watchEventChangefeed);
   }
 
   @Override


### PR DESCRIPTION
on the road to tackling https://github.com/pH14/fdb-zk/issues/3

This rewrites ZK watches to use a changefeed, rather than mapping them directly to FDB watches, which have different semantics. The issue ^ has the full explanation.

This PR will bring us closer to ZK, but overall we'll still be lack: integrating checks for active watches into read requests, handling the `setWatches` op when a client reconnects.