### PR TITLE
check watch changefeeds on read operations

### DIFF
--- a/src/main/java/com/ph14/fdb/zk/layer/FdbWatchManager.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbWatchManager.java
@@ -17,6 +17,10 @@ public class FdbWatchManager {
     this.watchChangefeed = watchChangefeed;
   }
 
+  public void checkForWatches(long sessionId, Watcher watcher) {
+    watchChangefeed.playChangefeed(sessionId, watcher);
+  }
+
   public void triggerNodeCreatedWatch(Transaction transaction, String zkPath) {
     watchChangefeed.appendToChangefeed(transaction, EventType.NodeCreated, zkPath);
   }

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbExistsOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbExistsOp.java
@@ -39,6 +39,8 @@ public class FdbExistsOp implements FdbOp<ExistsRequest, ExistsResponse> {
   public CompletableFuture<Result<ExistsResponse, KeeperException>> execute(Request zkRequest, Transaction transaction, ExistsRequest request) {
     List<String> path = FdbPath.toFdbPath(request.getPath());
 
+    fdbWatchManager.checkForWatches(zkRequest.sessionId, zkRequest.cnxn);
+
     final DirectorySubspace subspace;
     try {
       subspace = DirectoryLayer.getDefault().open(transaction, path).join();

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbGetChildrenWithStatOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbGetChildrenWithStatOp.java
@@ -36,6 +36,8 @@ public class FdbGetChildrenWithStatOp implements FdbOp<GetChildren2Request, GetC
   public CompletableFuture<Result<GetChildren2Response, KeeperException>> execute(Request zkRequest, Transaction transaction, GetChildren2Request request) {
     List<String> path = FdbPath.toFdbPath(request.getPath());
 
+    fdbWatchManager.checkForWatches(zkRequest.sessionId, zkRequest.cnxn);
+
     try {
       Stat stat = fdbNodeReader.getNodeStat(DirectoryLayer.getDefault().open(transaction, path).join(), transaction).join();
       List<String> childrenDirectoryNames = DirectoryLayer.getDefault().list(transaction, path).join();

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbGetDataOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbGetDataOp.java
@@ -41,6 +41,8 @@ public class FdbGetDataOp implements FdbOp<GetDataRequest, GetDataResponse> {
   public CompletableFuture<Result<GetDataResponse, KeeperException>> execute(Request zkRequest, Transaction transaction, GetDataRequest request) {
     List<String> path = FdbPath.toFdbPath(request.getPath());
 
+    fdbWatchManager.checkForWatches(zkRequest.sessionId, zkRequest.cnxn);
+
     final DirectorySubspace subspace;
     try {
       subspace = DirectoryLayer.getDefault().open(transaction, path).join();

--- a/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
+++ b/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
@@ -36,6 +36,7 @@ public class FdbBaseTest {
 
   protected FdbNodeWriter fdbNodeWriter;
   protected FdbWatchManager fdbWatchManager;
+  protected WatchEventChangefeed watchEventChangefeed;
   protected FdbNodeReader fdbNodeReader;
 
   protected FdbCreateOp fdbCreateOp;
@@ -57,7 +58,8 @@ public class FdbBaseTest {
     REQUEST = new Request(SERVER_CNXN, System.nanoTime(), 1, 2, null, Collections.emptyList());
 
     fdbNodeWriter = new FdbNodeWriter();
-    fdbWatchManager = new FdbWatchManager(new WatchEventChangefeed(fdb));
+    watchEventChangefeed = new WatchEventChangefeed(fdb);
+    fdbWatchManager = new FdbWatchManager(watchEventChangefeed);
     fdbNodeReader = new FdbNodeReader();
 
     fdbCreateOp = new FdbCreateOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager);


### PR DESCRIPTION
ZK watch semantics say that watch events that were written before the given transaction must be triggered before being able to see the data from those requests. This checks the watch changefeeds on read operations to ensure this happens if the FDB watch hasn't fired by the time a subsequent read op comes in

