### PR TITLE
basic ephemeral node tracking

### DIFF
--- a/src/main/java/com/ph14/fdb/zk/layer/FdbNode.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbNode.java
@@ -1,8 +1,8 @@
 package com.ph14.fdb.zk.layer;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
@@ -15,12 +15,18 @@ public class FdbNode {
   private final Stat stat;
   private final byte[] data;
   private final List<ACL> acls;
+  private final Optional<Long> ephemeralSessionId;
 
   public FdbNode(String zkPath, Stat stat, byte[] data, List<ACL> acls) {
+    this(zkPath, stat, data, acls, Optional.empty());
+  }
+
+  public FdbNode(String zkPath, Stat stat, byte[] data, List<ACL> acls, Optional<Long> ephemeralSessionId) {
     this.zkPath = zkPath;
     this.stat = stat;
     this.data = data;
     this.acls = acls;
+    this.ephemeralSessionId = ephemeralSessionId;
   }
 
   public String getZkPath() {
@@ -43,6 +49,10 @@ public class FdbNode {
     return acls;
   }
 
+  public Optional<Long> getEphemeralSessionId() {
+    return ephemeralSessionId;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -52,16 +62,16 @@ public class FdbNode {
       final FdbNode that = (FdbNode) obj;
       return Objects.equals(this.getZkPath(), that.getZkPath())
           && Objects.equals(this.getStat(), that.getStat())
-          && Arrays.equals(this.getData(), that.getData())
-          && Objects.equals(this.getAcls(), that.getAcls());
+          && Objects.equals(this.getData(), that.getData())
+          && Objects.equals(this.getAcls(), that.getAcls())
+          && Objects.equals(this.getEphemeralSessionId(), that.getEphemeralSessionId());
     }
     return false;
   }
 
   @Override
-  @SuppressWarnings("ArrayHashCode")
   public int hashCode() {
-    return Objects.hash(getZkPath(), getStat(), getData(), getAcls());
+    return Objects.hash(getZkPath(), getStat(), getData(), getAcls(), getEphemeralSessionId());
   }
 
   @Override
@@ -71,6 +81,7 @@ public class FdbNode {
         .add("stat", stat)
         .add("data", data)
         .add("acls", acls)
+        .add("ephemeralSessionId", ephemeralSessionId)
         .toString();
   }
 }

--- a/src/main/java/com/ph14/fdb/zk/layer/FdbNodeWriter.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbNodeWriter.java
@@ -101,7 +101,7 @@ public class FdbNodeWriter {
 
   private void writeStat(Transaction transaction, Subspace nodeSubspace, FdbNode fdbNode) {
     if (fdbNode.getStat() == null) {
-      writeStatForNewNode(transaction, nodeSubspace, fdbNode.getData(), Optional.empty());
+      writeStatForNewNode(transaction, nodeSubspace, fdbNode.getData(), fdbNode.getEphemeralSessionId());
     } else {
       writeStatFromExistingNode(transaction, nodeSubspace, fdbNode);
     }

--- a/src/main/java/com/ph14/fdb/zk/layer/changefeed/WatchEventChangefeed.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/changefeed/WatchEventChangefeed.java
@@ -24,7 +24,9 @@ import com.apple.foundationdb.tuple.Versionstamp;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
+@Singleton
 public class WatchEventChangefeed {
 
   private static final String ACTIVE_WATCH_NAMESPACE = "fdb-zk-watch-active";

--- a/src/main/java/com/ph14/fdb/zk/layer/ephemeral/FdbEphemeralNodeManager.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/ephemeral/FdbEphemeralNodeManager.java
@@ -41,6 +41,10 @@ public class FdbEphemeralNodeManager {
                 kv -> Tuple.fromBytes(kv.getKey()).getString(2)));
   }
 
+  public void removeNode(Transaction transaction, String zkPath, long sessionId) {
+    transaction.clear(Tuple.from(ephemeralNodeSubspace, sessionId, zkPath).pack());
+  }
+
   public void clearEphemeralNodesForSession(Transaction transaction, long sessionId) {
     transaction.clear(Range.startsWith(Tuple.from(ephemeralNodeSubspace, sessionId).pack()));
   }

--- a/src/main/java/com/ph14/fdb/zk/layer/ephemeral/FdbEphemeralNodeManager.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/ephemeral/FdbEphemeralNodeManager.java
@@ -1,0 +1,48 @@
+package com.ph14.fdb.zk.layer.ephemeral;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.directory.DirectoryLayer;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.collect.Iterables;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class FdbEphemeralNodeManager {
+
+  private static final String EPHEMERAL_NODE_SUBSPACE = "fdb-zk-ephemeral-nodes";
+  private static final byte[] EMPTY_VALUE = new byte[0];
+
+  private final byte[] ephemeralNodeSubspace;
+
+  @Inject
+  public FdbEphemeralNodeManager(Database fdb) {
+    this.ephemeralNodeSubspace = DirectoryLayer.getDefault().createOrOpen(
+        fdb.createTransaction(),
+        Collections.singletonList(EPHEMERAL_NODE_SUBSPACE))
+        .join().pack();
+  }
+
+  public void addEphemeralNode(Transaction transaction, String zkPath, long sessionId) {
+    transaction.set(Tuple.from(ephemeralNodeSubspace, sessionId, zkPath).pack(), EMPTY_VALUE);
+  }
+
+  public CompletableFuture<Iterable<String>> getEphemeralNodeZkPaths(Transaction transaction, long sessionId) {
+    return transaction.getRange(Range.startsWith(Tuple.from(ephemeralNodeSubspace, sessionId).pack()))
+        .asList()
+        .thenApply(kvs ->
+            Iterables.transform(
+                kvs,
+                kv -> Tuple.fromBytes(kv.getKey()).getString(2)));
+  }
+
+  public void clearEphemeralNodesForSession(Transaction transaction, long sessionId) {
+    transaction.clear(Range.startsWith(Tuple.from(ephemeralNodeSubspace, sessionId).pack()));
+  }
+
+}

--- a/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
+++ b/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
@@ -72,7 +72,7 @@ public class FdbBaseTest {
     fdbExistsOp = new FdbExistsOp(fdbNodeReader, fdbWatchManager);
     fdbGetChildrenWithStatOp = new FdbGetChildrenWithStatOp(fdbNodeReader, fdbWatchManager);
     fdbGetChildrenOp = new FdbGetChildrenOp(fdbGetChildrenWithStatOp);
-    fdbDeleteOp = new FdbDeleteOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager);
+    fdbDeleteOp = new FdbDeleteOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager, fdbEphemeralNodeManager);
 
     fdb.run(tr -> {
       DirectoryLayer.getDefault().removeIfExists(tr, Collections.singletonList(FdbPath.ROOT_PATH)).join();

--- a/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
+++ b/src/test/java/com/ph14/fdb/zk/FdbBaseTest.java
@@ -19,6 +19,7 @@ import com.ph14.fdb.zk.layer.FdbNodeWriter;
 import com.ph14.fdb.zk.layer.FdbPath;
 import com.ph14.fdb.zk.layer.FdbWatchManager;
 import com.ph14.fdb.zk.layer.changefeed.WatchEventChangefeed;
+import com.ph14.fdb.zk.layer.ephemeral.FdbEphemeralNodeManager;
 import com.ph14.fdb.zk.ops.FdbCreateOp;
 import com.ph14.fdb.zk.ops.FdbDeleteOp;
 import com.ph14.fdb.zk.ops.FdbExistsOp;
@@ -38,6 +39,7 @@ public class FdbBaseTest {
   protected FdbWatchManager fdbWatchManager;
   protected WatchEventChangefeed watchEventChangefeed;
   protected FdbNodeReader fdbNodeReader;
+  protected FdbEphemeralNodeManager fdbEphemeralNodeManager;
 
   protected FdbCreateOp fdbCreateOp;
   protected FdbGetDataOp fdbGetDataOp;
@@ -61,8 +63,9 @@ public class FdbBaseTest {
     watchEventChangefeed = new WatchEventChangefeed(fdb);
     fdbWatchManager = new FdbWatchManager(watchEventChangefeed);
     fdbNodeReader = new FdbNodeReader();
+    fdbEphemeralNodeManager = new FdbEphemeralNodeManager(fdb);
 
-    fdbCreateOp = new FdbCreateOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager);
+    fdbCreateOp = new FdbCreateOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager, fdbEphemeralNodeManager);
     fdbGetDataOp = new FdbGetDataOp(fdbNodeReader, fdbWatchManager);
     fdbSetDataOp = new FdbSetDataOp(fdbNodeReader, fdbNodeWriter, fdbWatchManager);
     fdbExistsOp = new FdbExistsOp(fdbNodeReader, fdbWatchManager);


### PR DESCRIPTION
beginning down the road of https://github.com/pH14/fdb-zk/issues/4

adds in a new subspace that tracks ephemeral nodes, so we can quickly find an expiring session's ephemeral nodes for removal.