### PR TITLE
coordinating clock for finding expiring nodes

### DIFF
--- a/src/main/java/com/ph14/fdb/zk/session/CoordinatingClock.java
+++ b/src/main/java/com/ph14/fdb/zk/session/CoordinatingClock.java
@@ -1,0 +1,137 @@
+package com.ph14.fdb.zk.session;
+
+import java.io.Closeable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDBException;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * Coordinating clock to pick a client to execute some function when elected.
+ *
+ * Each clock participant reads the clock key, which is a timestamp
+ * of the end of the current tick. Clients wait until their local time ~= this value,
+ * and then try to write ts + tick_interval. If all of their transactions were
+ * open simultaneously, then only one write should win and the rest get conflicts.
+ * The winning write is the "leader" until the next tick interval.
+ *
+ * This doesn't guarantee single-leaders, but ought to cull most clients each tick.
+ */
+public class CoordinatingClock implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoordinatingClock.class);
+
+  // this should be configurable
+  private static final long TICK_TIME_MILLIS = 1000;
+
+  private final Database fdb;
+  private final ExecutorService executorService;
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  private final String clockName;
+  private final byte[] clockKey;
+  private final Runnable onElection;
+
+  private CoordinatingClock(Database fdb, String clockName, Runnable onElection) {
+    this.fdb = fdb;
+
+    this.executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+        .setNameFormat("fdb-clock-" + clockName)
+        .setDaemon(true)
+        .build());
+
+    this.clockName = clockName;
+    this.clockKey = clockName.getBytes(Charsets.UTF_8);
+    this.onElection = onElection;
+
+    executorService.submit(() -> {
+      while (!isClosed.get()) {
+        keepTime();
+      }
+    });
+  }
+
+  public static CoordinatingClock start(Database fdb, String clockName, Runnable onElection) {
+    return new CoordinatingClock(fdb, clockName, onElection);
+  }
+
+  @Override
+  public void close() {
+    isClosed.set(true);
+    executorService.shutdown();
+
+    try {
+      executorService.awaitTermination(10, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void keepTime() {
+    try {
+      Transaction transaction = fdb.createTransaction();
+
+      byte[] currentTickToWaitFor = transaction.get(clockKey).join();
+
+      long now = System.currentTimeMillis();
+      long nowRounded = TICK_TIME_MILLIS * (now / TICK_TIME_MILLIS);
+
+      if (currentTickToWaitFor == null) {
+        transaction.set(clockKey, ByteArrayUtil.encodeInt(nowRounded + TICK_TIME_MILLIS));
+        transaction.commit().join();
+        return;
+      }
+
+      long nextPersistedTick = ByteArrayUtil.decodeInt(currentTickToWaitFor) + TICK_TIME_MILLIS;
+
+      boolean mustRetryBeforeEligibleForLeader = false;
+      // our clock is ahead of the next tick, we'll try to advance it further
+      if (now > nextPersistedTick) {
+        nextPersistedTick += TICK_TIME_MILLIS;
+        mustRetryBeforeEligibleForLeader = true;
+      } else {
+        // we're behind, so wait until we think our real-time is the next tick
+        Thread.sleep(nextPersistedTick - now);
+      }
+
+      transaction.set(clockKey, ByteArrayUtil.encodeInt(nextPersistedTick));
+      transaction.commit().join();
+
+      if (mustRetryBeforeEligibleForLeader) {
+        return;
+      }
+    } catch (Exception e) {
+      for (Throwable throwable : Throwables.getCausalChain(e)) {
+        if (throwable instanceof FDBException) {
+          FDBException fdbException = (FDBException) throwable;
+          if (fdbException.getCode() == 1020) {
+            // this is a conflict exception, which is expected for roughly all but one client per tick
+            return;
+          }
+        }
+      }
+
+      // we hit a real exception. we might want to apply backpressure here.
+      // it's risky to entirely drop the loop, since a transient error that
+      // impacts all clients could stop all ticks
+      LOG.error("Exception hit in leader clock", e);
+      return;
+    }
+
+    // we won! by which we mean we didn't get a conflict
+    LOG.info("elected leader of {} clock @ {}", clockName, System.currentTimeMillis());
+
+    onElection.run();
+  }
+
+}

--- a/src/main/java/com/ph14/fdb/zk/session/CoordinatingClock.java
+++ b/src/main/java/com/ph14/fdb/zk/session/CoordinatingClock.java
@@ -18,6 +18,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -75,6 +76,8 @@ public class CoordinatingClock implements Closeable {
   }
 
   public CoordinatingClock start() {
+    Preconditions.checkState(!isClosed.get(), "cannot start clock, already closed");
+
     executorService.submit(() -> {
       while (!isClosed.get()) {
         keepTime();

--- a/src/test/java/com/ph14/fdb/zk/session/CoordinatingClockTest.java
+++ b/src/test/java/com/ph14/fdb/zk/session/CoordinatingClockTest.java
@@ -1,36 +1,181 @@
 package com.ph14.fdb.zk.session;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+import com.apple.foundationdb.tuple.Tuple;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 
 public class CoordinatingClockTest {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CoordinatingClockTest.class);
+  private Database fdb;
+  private AtomicBoolean wasLeader;
+
+  @Before
+  public void setUp() {
+    this.fdb = FDB.selectAPIVersion(600).open();
+    this.wasLeader = new AtomicBoolean(false);
+
+    fdb.run(tr -> {
+      tr.clear(Range.startsWith(CoordinatingClock.KEY_PREFIX));
+      return null;
+    });
+  }
 
   @Test
-  public void itDoes() throws InterruptedException {
-    FDB fdb = FDB.selectAPIVersion(600);
-    Database db = fdb.open();
+  public void itStartsAClockWithoutAnInitialKey() {
+    CoordinatingClock coordinatingClock = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> wasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1050), ZoneId.systemDefault()),
+        OptionalLong.of(500));
 
-    List<CoordinatingClock> coordinatingClocks = new ArrayList<>();
+    assertThat(coordinatingClock.getCurrentTick()).isEmpty();
 
-    for (int i = 0; i < 100; i++) {
-      final int id = i;
-      coordinatingClocks.add(CoordinatingClock.start(db, "session", () -> LOG.info("clock {} elected", id)));
-    }
+    coordinatingClock.runOnce();
 
-    Thread.sleep(10000);
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1500);
+    assertThat(wasLeader.get()).isFalse();
+  }
 
-    coordinatingClocks.forEach(CoordinatingClock::close);
+  @Test
+  public void itAdvancesAClockWhenKeyIsInThePast() {
+    fdb.run(tr -> {
+      tr.set(Tuple.from(CoordinatingClock.PREFIX, "session".getBytes(Charsets.UTF_8)).pack(), ByteArrayUtil.encodeInt(500));
+      return null;
+    });
 
-    LOG.info("Shutdown");
+    CoordinatingClock coordinatingClock = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> wasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1234), ZoneId.systemDefault()),
+        OptionalLong.of(500));
+
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(500);
+
+    coordinatingClock.runOnce();
+
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1500);
+    assertThat(wasLeader.get()).isFalse();
+  }
+
+  @Test
+  public void itWaitsAndAdvancesClockWhenKeyIsInTheFuture() {
+    fdb.run(tr -> {
+      tr.set(Tuple.from(CoordinatingClock.PREFIX, "session".getBytes(Charsets.UTF_8)).pack(), ByteArrayUtil.encodeInt(1234));
+      return null;
+    });
+
+    CoordinatingClock coordinatingClock = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> wasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1234), ZoneId.systemDefault()),
+        OptionalLong.of(500));
+
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1234);
+
+    coordinatingClock.runOnce();
+
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1500);
+    assertThat(wasLeader.get()).isTrue();
+  }
+
+  @Test
+  public void itAdvancesManyTimes() {
+    CoordinatingClock coordinatingClock = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> wasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1050), ZoneId.systemDefault()),
+        OptionalLong.of(100));
+
+    assertThat(coordinatingClock.getCurrentTick()).isEmpty();
+
+    coordinatingClock.runOnce();
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1100);
+    assertThat(wasLeader.get()).isFalse();
+
+    coordinatingClock.runOnce();
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1200);
+    assertThat(wasLeader.get()).isTrue();
+
+    coordinatingClock.runOnce();
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1300);
+    assertThat(wasLeader.get()).isTrue();
+
+    coordinatingClock.runOnce();
+    assertThat(coordinatingClock.getCurrentTick()).hasValue(1400);
+    assertThat(wasLeader.get()).isTrue();
+  }
+
+  @Test
+  public void itOnlyLetsOneClockBecomeTheLeaderBestEffort() {
+    fdb.run(tr -> {
+      tr.set(Tuple.from(CoordinatingClock.PREFIX, "session".getBytes(Charsets.UTF_8)).pack(), ByteArrayUtil.encodeInt(1000));
+      return null;
+    });
+
+    AtomicBoolean clockTwoWasLeader = new AtomicBoolean(false);
+    AtomicBoolean clockThreeWasLeader = new AtomicBoolean(false);
+
+    CoordinatingClock coordinatingClockOne = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> wasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1000), ZoneId.systemDefault()),
+        OptionalLong.of(500));
+
+    CoordinatingClock coordinatingClockTwo = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> clockTwoWasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1000), ZoneId.systemDefault()),
+        OptionalLong.of(500));
+
+    CoordinatingClock coordinatingClockThree = CoordinatingClock.from(
+        fdb,
+        "session",
+        () -> clockThreeWasLeader.set(true),
+        Clock.fixed(Instant.ofEpochMilli(1000), ZoneId.systemDefault()),
+        OptionalLong.of(500));
+
+    List<CoordinatingClock> clocks = ImmutableList.of(coordinatingClockOne, coordinatingClockTwo, coordinatingClockThree);
+
+    clocks.stream()
+        .map(clock -> CompletableFuture.runAsync(clock::runOnce))
+        .collect(Collectors.toList())
+        .forEach(CompletableFuture::join);
+
+    // it's possible this could fail with an unfortunate scheduling of the futures, where they wind up running serially
+    assertThat(wasLeader.get() ^ clockTwoWasLeader.get() ^ clockThreeWasLeader.get()).isTrue();
+    assertThat(coordinatingClockOne.getCurrentTick()).hasValue(1500);
+
+    clocks.stream()
+        .map(clock -> CompletableFuture.runAsync(clock::runOnce))
+        .collect(Collectors.toList())
+        .forEach(CompletableFuture::join);
+
+    assertThat(wasLeader.get() ^ clockTwoWasLeader.get() ^ clockThreeWasLeader.get()).isTrue();
+    assertThat(coordinatingClockOne.getCurrentTick()).hasValue(2000);
   }
 
 }

--- a/src/test/java/com/ph14/fdb/zk/session/CoordinatingClockTest.java
+++ b/src/test/java/com/ph14/fdb/zk/session/CoordinatingClockTest.java
@@ -1,0 +1,36 @@
+package com.ph14.fdb.zk.session;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+
+public class CoordinatingClockTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoordinatingClockTest.class);
+
+  @Test
+  public void itDoes() throws InterruptedException {
+    FDB fdb = FDB.selectAPIVersion(600);
+    Database db = fdb.open();
+
+    List<CoordinatingClock> coordinatingClocks = new ArrayList<>();
+
+    for (int i = 0; i < 100; i++) {
+      final int id = i;
+      coordinatingClocks.add(CoordinatingClock.start(db, "session", () -> LOG.info("clock {} elected", id)));
+    }
+
+    Thread.sleep(10000);
+
+    coordinatingClocks.forEach(CoordinatingClock::close);
+
+    LOG.info("Shutdown");
+  }
+
+}

--- a/src/test/java/com/ph14/fdb/zk/session/CoordinatingClockTest.java
+++ b/src/test/java/com/ph14/fdb/zk/session/CoordinatingClockTest.java
@@ -169,6 +169,10 @@ public class CoordinatingClockTest {
     assertThat(wasLeader.get() ^ clockTwoWasLeader.get() ^ clockThreeWasLeader.get()).isTrue();
     assertThat(coordinatingClockOne.getCurrentTick()).hasValue(1500);
 
+    wasLeader.set(false);
+    clockTwoWasLeader.set(false);
+    clockThreeWasLeader.set(false);
+
     clocks.stream()
         .map(clock -> CompletableFuture.runAsync(clock::runOnce))
         .collect(Collectors.toList())


### PR DESCRIPTION
Creates a new primitive `CoordinatingClock` that clients can participate in (this could be interesting outside of `fdb-zk`). Clients read the clock, thread sleep until `current_clock + tick_interval`, and then try to write the new time. ~all but one client will get conflicts, and the winning writer gets to perform whatever leader-y function it needs to

Later will add a follow-up PR that uses it to cull expiring session data + ephemeral nodes