### PR TITLE
update node and session deletion code paths

### DIFF
--- a/src/main/java/com/ph14/fdb/zk/layer/FdbNodeReader.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbNodeReader.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.async.AsyncUtil;
+import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
@@ -31,6 +32,10 @@ public class FdbNodeReader {
 
   @Inject
   public FdbNodeReader() {
+  }
+
+  public CompletableFuture<DirectorySubspace> getNodeDirectory(Transaction transaction, String zkPath) {
+    return DirectoryLayer.getDefault().open(transaction, FdbPath.toFdbPath(zkPath));
   }
 
   public CompletableFuture<FdbNode> getNode(DirectorySubspace nodeSubspace, Transaction transaction) {

--- a/src/main/java/com/ph14/fdb/zk/layer/FdbNodeWriter.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbNodeWriter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -14,6 +15,7 @@ import com.apple.foundationdb.KeyValue;
 import com.apple.foundationdb.MutationType;
 import com.apple.foundationdb.Range;
 import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.directory.DirectorySubspace;
 import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
@@ -95,8 +97,8 @@ public class FdbNodeWriter {
     }
   }
 
-  public void deleteNode(Transaction transaction, Subspace nodeSubspace) {
-    transaction.clear(nodeSubspace.range());
+  public CompletableFuture<Void> deleteNodeAsync(Transaction transaction, DirectorySubspace nodeSubspace) {
+    return nodeSubspace.remove(transaction);
   }
 
   private void writeStat(Transaction transaction, Subspace nodeSubspace, FdbNode fdbNode) {

--- a/src/main/java/com/ph14/fdb/zk/layer/FdbWatchManager.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/FdbWatchManager.java
@@ -22,19 +22,19 @@ public class FdbWatchManager {
   }
 
   public void triggerNodeCreatedWatch(Transaction transaction, String zkPath) {
-    watchChangefeed.appendToChangefeed(transaction, EventType.NodeCreated, zkPath);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeCreated, zkPath).join();
   }
 
   public void triggerNodeUpdatedWatch(Transaction transaction, String zkPath) {
-    watchChangefeed.appendToChangefeed(transaction, EventType.NodeDataChanged, zkPath);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeDataChanged, zkPath).join();
   }
 
   public void triggerNodeDeletedWatch(Transaction transaction, String zkPath) {
-    watchChangefeed.appendToChangefeed(transaction, EventType.NodeDeleted, zkPath);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeDeleted, zkPath).join();
   }
 
   public void triggerNodeChildrenWatch(Transaction transaction, String zkPath) {
-    watchChangefeed.appendToChangefeed(transaction, EventType.NodeChildrenChanged, zkPath);
+    watchChangefeed.appendToChangefeed(transaction, EventType.NodeChildrenChanged, zkPath).join();
   }
 
   public void addNodeCreatedWatch(Transaction transaction, String zkPath, Watcher watcher, long sessionId) {

--- a/src/main/java/com/ph14/fdb/zk/layer/changefeed/WatchEventChangefeed.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/changefeed/WatchEventChangefeed.java
@@ -67,25 +67,28 @@ public class WatchEventChangefeed {
    * * Add an update to the active-watcher changefeeds for a (session, watchEventType, zkPath)
    * * Triggers all FDB watches for the changefeed
    */
-  public void appendToChangefeed(Transaction transaction, EventType eventType, String zkPath) {
+  public CompletableFuture<Void> appendToChangefeed(Transaction transaction, EventType eventType, String zkPath) {
     Range activeWatches = Range.startsWith(Tuple.from(ACTIVE_WATCH_NAMESPACE, zkPath, eventType.getIntValue()).pack());
-    List<KeyValue> keyValues = transaction.getRange(activeWatches).asList().join();
 
-    for (KeyValue keyValue : keyValues) {
-      long sessionId = Tuple.fromBytes(keyValue.getKey()).getLong(3);
+    return transaction.getRange(activeWatches).asList()
+        .thenApply(keyValues -> {
+          for (KeyValue keyValue : keyValues) {
+            long sessionId = Tuple.fromBytes(keyValue.getKey()).getLong(3);
 
-      Tuple changefeedKey = Tuple.from(CHANGEFEED_NAMESPACE, sessionId, Versionstamp.incomplete(), eventType.getIntValue());
-      // append the event to the changefeed of each ZK watcher
-      transaction.mutate(MutationType.SET_VERSIONSTAMPED_KEY, changefeedKey.packWithVersionstamp(), Tuple.from(zkPath).pack());
+            Tuple changefeedKey = Tuple.from(CHANGEFEED_NAMESPACE, sessionId, Versionstamp.incomplete(), eventType.getIntValue());
+            // append the event to the changefeed of each ZK watcher
+            transaction.mutate(MutationType.SET_VERSIONSTAMPED_KEY, changefeedKey.packWithVersionstamp(), Tuple.from(zkPath).pack());
 
-      // update the watched trigger-key for each ZK watcher, so they know to check their changefeeds for updates
-      transaction.mutate(
-          MutationType.SET_VERSIONSTAMPED_VALUE,
-          Tuple.from(CHANGEFEED_TRIGGER_NAMESPACE, sessionId, eventType.getIntValue()).pack(),
-          Tuple.from(Versionstamp.incomplete()).packWithVersionstamp());
-    }
+            // update the watched trigger-key for each ZK watcher, so they know to check their changefeeds for updates
+            transaction.mutate(
+                MutationType.SET_VERSIONSTAMPED_VALUE,
+                Tuple.from(CHANGEFEED_TRIGGER_NAMESPACE, sessionId, eventType.getIntValue()).pack(),
+                Tuple.from(Versionstamp.incomplete()).packWithVersionstamp());
+          }
 
-    transaction.clear(activeWatches);
+          transaction.clear(activeWatches);
+          return null;
+        });
   }
 
   public void playChangefeed(long sessionId, Watcher watcher) {

--- a/src/main/java/com/ph14/fdb/zk/ops/FdbDeleteOp.java
+++ b/src/main/java/com/ph14/fdb/zk/ops/FdbDeleteOp.java
@@ -98,10 +98,10 @@ public class FdbDeleteOp implements FdbOp<DeleteRequest, DeleteResult> {
       fdbEphemeralNodeManager.removeNode(transaction, request.getPath(), zkRequest.sessionId);
     }
 
-    nodeSubspace.remove(transaction).join();
+    fdbNodeWriter.deleteNodeAsync(transaction, nodeSubspace).join();
 
     fdbWatchManager.triggerNodeDeletedWatch(transaction, request.getPath());
-    fdbWatchManager.triggerNodeChildrenWatch(transaction, request.getPath());
+    fdbWatchManager.triggerNodeChildrenWatch(transaction, FdbPath.toZkParentPath(request.getPath()));
 
     return CompletableFuture.completedFuture(Result.ok(new DeleteResult()));
   }

--- a/src/main/java/com/ph14/fdb/zk/session/FdbSessionCleanup.java
+++ b/src/main/java/com/ph14/fdb/zk/session/FdbSessionCleanup.java
@@ -1,0 +1,58 @@
+package com.ph14.fdb.zk.session;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.async.AsyncUtil;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.ph14.fdb.zk.layer.FdbNodeReader;
+import com.ph14.fdb.zk.layer.FdbNodeWriter;
+import com.ph14.fdb.zk.layer.changefeed.WatchEventChangefeed;
+import com.ph14.fdb.zk.layer.ephemeral.FdbEphemeralNodeManager;
+
+@Singleton
+public class FdbSessionCleanup {
+
+  private final Database fdb;
+  private final WatchEventChangefeed watchEventChangefeed;
+  private final FdbNodeWriter fdbNodeWriter;
+  private final FdbNodeReader fdbNodeReader;
+  private final FdbEphemeralNodeManager fdbEphemeralNodeManager;
+
+  @Inject
+  public FdbSessionCleanup(Database fdb,
+                           WatchEventChangefeed watchEventChangefeed,
+                           FdbNodeWriter fdbNodeWriter,
+                           FdbNodeReader fdbNodeReader,
+                           FdbEphemeralNodeManager fdbEphemeralNodeManager) {
+    this.fdb = fdb;
+    this.watchEventChangefeed = watchEventChangefeed;
+    this.fdbNodeWriter = fdbNodeWriter;
+    this.fdbNodeReader = fdbNodeReader;
+    this.fdbEphemeralNodeManager = fdbEphemeralNodeManager;
+  }
+
+  public CompletableFuture<Void> removeAllSessionEntries(long sessionId) {
+    return fdb.run(tr -> {
+      List<CompletableFuture<Void>> deletions = new ArrayList<>();
+
+      deletions.add(watchEventChangefeed.clearAllWatchesForSession(tr, sessionId));
+
+      for (String zkPath : fdbEphemeralNodeManager.getEphemeralNodeZkPaths(tr, sessionId).join()) {
+        deletions.add(
+            fdbNodeReader.getNodeDirectory(tr, zkPath)
+                .thenCompose(nodeDirectory -> fdbNodeWriter.deleteNodeAsync(tr, nodeDirectory)));
+      }
+
+      fdbEphemeralNodeManager.clearEphemeralNodesForSession(tr, sessionId);
+
+      // TODO: clean up session information once it's finished
+
+      return AsyncUtil.whenAll(deletions);
+    });
+  }
+
+}

--- a/src/test/java/com/ph14/fdb/zk/ops/FdbExistsOpTest.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/FdbExistsOpTest.java
@@ -117,7 +117,7 @@ public class FdbExistsOpTest extends FdbBaseTest {
     fdb.run(tr -> {
       CompletableFuture<Void> fdbWatch = watchEventChangefeed.setZKChangefeedWatch(tr, SERVER_CNXN, REQUEST.sessionId, EventType.NodeCreated, "abc");
       fdbWatch.cancel(true);
-      watchEventChangefeed.appendToChangefeed(tr, EventType.NodeCreated, "abc");
+      watchEventChangefeed.appendToChangefeed(tr, EventType.NodeCreated, "abc").join();
       return null;
     });
 

--- a/src/test/java/com/ph14/fdb/zk/ops/FdbGetChildrenWithStatOpTest.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/FdbGetChildrenWithStatOpTest.java
@@ -111,7 +111,7 @@ public class FdbGetChildrenWithStatOpTest extends FdbBaseTest {
     fdb.run(tr -> {
       CompletableFuture<Void> fdbWatch = watchEventChangefeed.setZKChangefeedWatch(tr, SERVER_CNXN, REQUEST.sessionId, EventType.NodeCreated, "abc");
       fdbWatch.cancel(true);
-      watchEventChangefeed.appendToChangefeed(tr, EventType.NodeCreated, "abc");
+      watchEventChangefeed.appendToChangefeed(tr, EventType.NodeCreated, "abc").join();
       return null;
     });
 

--- a/src/test/java/com/ph14/fdb/zk/ops/FdbGetDataOpTest.java
+++ b/src/test/java/com/ph14/fdb/zk/ops/FdbGetDataOpTest.java
@@ -128,7 +128,7 @@ public class FdbGetDataOpTest extends FdbBaseTest {
     fdb.run(tr -> {
       CompletableFuture<Void> fdbWatch = watchEventChangefeed.setZKChangefeedWatch(tr, SERVER_CNXN, REQUEST.sessionId, EventType.NodeCreated, "abc");
       fdbWatch.cancel(true);
-      watchEventChangefeed.appendToChangefeed(tr, EventType.NodeCreated, "abc");
+      watchEventChangefeed.appendToChangefeed(tr, EventType.NodeCreated, "abc").join();
       return null;
     });
 


### PR DESCRIPTION
* the delete op was missing tests for its deletion watches (+ a bug for parent nodes)
* adds a new session remover that clears all of the state a session can leave (documented in https://github.com/pH14/fdb-zk/issues/7#issuecomment-531443670)