### PR TITLE
handle all client session request types in fdbzk

### DIFF
--- a/src/main/java/com/ph14/fdb/zk/FdbZooKeeperServer.java
+++ b/src/main/java/com/ph14/fdb/zk/FdbZooKeeperServer.java
@@ -97,7 +97,7 @@ public class FdbZooKeeperServer extends ZooKeeperServer {
 
     fdbSessionClock.run();
 
-    this.firstProcessor = new FdbRequestProcessor(sessionTracker, firstProcessor, getZKDatabase(), fdbZooKeeper);
+    this.firstProcessor = new FdbRequestProcessor(null, this, fdbZooKeeper);
   }
 
 }

--- a/src/main/java/com/ph14/fdb/zk/layer/ephemeral/FdbEphemeralNodeManager.java
+++ b/src/main/java/com/ph14/fdb/zk/layer/ephemeral/FdbEphemeralNodeManager.java
@@ -17,32 +17,31 @@ public class FdbEphemeralNodeManager {
   private static final String EPHEMERAL_NODE_SUBSPACE = "fdb-zk-ephemeral-nodes";
   private static final byte[] EMPTY_VALUE = new byte[0];
 
-  private final Subspace ephemeralNodeSubspace;
+  private final byte[] ephemeralNodeSubspace;
 
   @Inject
   public FdbEphemeralNodeManager() {
-    this.ephemeralNodeSubspace = new Subspace(EPHEMERAL_NODE_SUBSPACE.getBytes(Charsets.UTF_8));
+    this.ephemeralNodeSubspace = new Subspace(EPHEMERAL_NODE_SUBSPACE.getBytes(Charsets.UTF_8)).pack();
   }
 
   public void addEphemeralNode(Transaction transaction, String zkPath, long sessionId) {
-    transaction.set(ephemeralNodeSubspace.pack(Tuple.from(sessionId, zkPath)), EMPTY_VALUE);
+    transaction.set(Tuple.from(ephemeralNodeSubspace, sessionId, zkPath).pack(), EMPTY_VALUE);
   }
 
   public CompletableFuture<Iterable<String>> getEphemeralNodeZkPaths(Transaction transaction, long sessionId) {
-    return transaction.getRange(Range.startsWith(ephemeralNodeSubspace.pack(sessionId)))
+    return transaction.getRange(Range.startsWith(Tuple.from(ephemeralNodeSubspace, sessionId).pack()))
         .asList()
-        .thenApply(kvs ->
-            Iterables.transform(
-                kvs,
-                kv -> Tuple.fromBytes(kv.getKey()).getString(2)));
+        .thenApply(kvs -> Iterables.transform(
+            kvs,
+            kv -> Tuple.fromBytes(kv.getKey()).getString(2)));
   }
 
   public void removeNode(Transaction transaction, String zkPath, long sessionId) {
-    transaction.clear(ephemeralNodeSubspace.pack(Tuple.from(sessionId, zkPath)));
+    transaction.clear(Tuple.from(ephemeralNodeSubspace, sessionId, zkPath).pack());
   }
 
   public void clearEphemeralNodesForSession(Transaction transaction, long sessionId) {
-    transaction.clear(Range.startsWith(ephemeralNodeSubspace.pack(sessionId)));
+    transaction.clear(Range.startsWith(Tuple.from(ephemeralNodeSubspace, sessionId).pack()));
   }
 
 }

--- a/src/main/java/com/ph14/fdb/zk/session/CoordinatingClock.java
+++ b/src/main/java/com/ph14/fdb/zk/session/CoordinatingClock.java
@@ -78,8 +78,12 @@ public class CoordinatingClock implements Closeable {
     Preconditions.checkState(!isClosed.get(), "cannot start clock, already closed");
 
     executorService.scheduleAtFixedRate(() -> {
-      if (!isClosed.get()) {
-        keepTime();
+      try {
+        if (!isClosed.get()) {
+          keepTime();
+        }
+      } catch (Exception e) {
+        LOG.error("Error in coordinating clock", e);
       }
     }, 0, tickMillis, TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
fixes https://github.com/pH14/fdb-zk/issues/14

This one is a pretty big deal, it means we fully remove the fallback to the ZK `RequestProcessors` and exclusively handle things at the `ZookeeperServer --> FdbZookeeperProcessor` levels, which is about as barebones as is reasonable without rewriting the connection handling code